### PR TITLE
Legg til sif-code-scan i CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -42,3 +42,9 @@ jobs:
         run: |
           docker build . --pull --tag $BASE_IMAGE:latest
           docker push $BASE_IMAGE:latest
+
+  sif-code-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,5 +47,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@v1
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -46,5 +46,6 @@ jobs:
   sif-code-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Pek din klients discovery url til host + port `/.well-known/openid-configuration
 ## OIDC Authorization flow uten interaksjon
 - Default vil man bli spurt om Bruker ID og navn i en form. Om man ønsker å omgå manuelt steg under innloggingen kan disse to settes som query-paramter på discovery urlen.
 
-Eks; `/.well-known/openid-configuration?name=Gizmo%20The%20Cat&user_id=22046474256`
+Eks; `/.well-known/openid-configuration?name=Gizmo%20The%20Cat&user_id=17420373147`


### PR DESCRIPTION
Legger til sif-code-scan som en parallell jobb i CI-workflowen. Denne sjekker koden for sensitive data som fødselsnummer.